### PR TITLE
Use getHead to fetch latest block height

### DIFF
--- a/indexer/client.go
+++ b/indexer/client.go
@@ -233,17 +233,17 @@ func (c *Client) GetLatest(ctx context.Context, tr cStructs.TaskRequest, stream 
 
 	go c.sendRespLoop(ctx, tr.Id, out, stream, fin)
 
-	block, err := c.proxy.GetBlockByHeight(ctx, 0)
+	head, err := c.proxy.GetHead(ctx)
 	if err != nil {
 		stream.Send(cStructs.TaskResponse{
 			Id:    tr.Id,
-			Error: cStructs.TaskError{Msg: fmt.Sprintf("Could not fetch latest block from proxy: %s", err.Error())},
+			Error: cStructs.TaskError{Msg: fmt.Sprintf("Could not fetch head from proxy: %s", err.Error())},
 			Final: true,
 		})
 		return
 	}
 
-	hr := c.getLatestBlockHeightRange(ctx, ldr.LastHeight, uint64(block.Block.Header.Height))
+	hr := c.getLatestBlockHeightRange(ctx, ldr.LastHeight, uint64(head.GetHeight()))
 
 	if err := c.sendTransactionsInRange(ctx, hr, out); err != nil {
 		stream.Send(cStructs.TaskResponse{

--- a/indexer/client_test.go
+++ b/indexer/client_test.go
@@ -258,7 +258,7 @@ func (ic *IndexerClientTest) TestGetAccountBalance_UnmarshalError() {
 }
 
 func (ic *IndexerClientTest) TestGetLatest_OK() {
-	ic.ProxyClient.On("GetBlockByHeight", mock.AnythingOfType("*context.cancelCtx"), uint64(0)).Return(utils.BlockResponse(ic.BlockResponse[1]), nil)
+	ic.ProxyClient.On("GetHead", mock.AnythingOfType("*context.cancelCtx")).Return(utils.HeadResponse(int64(ic.Height[1])), nil)
 	ic.ProxyClient.On("GetBlockByHeight", mock.AnythingOfType("*context.cancelCtx"), ic.Height[0]).Return(utils.BlockResponse(ic.BlockResponse[0]), nil)
 	ic.ProxyClient.On("GetBlockByHeight", mock.AnythingOfType("*context.cancelCtx"), ic.Height[1]).Return(utils.BlockResponse(ic.BlockResponse[1]), nil)
 	ic.ProxyClient.On("GetEventsByHeight", mock.AnythingOfType("*context.cancelCtx"), ic.Height[0]).Return(utils.EventsResponse(ic.EventsResponse[0]), nil)
@@ -367,9 +367,9 @@ func (ic *IndexerClientTest) TestGetLatest_LatestDataRequestUnmarshalError() {
 	}
 }
 
-func (ic *IndexerClientTest) TestGetLatest_BlockResponseError() {
-	e := errors.New("new block error")
-	ic.ProxyClient.On("GetBlockByHeight", mock.AnythingOfType("*context.cancelCtx"), uint64(0)).Return(&blockpb.GetByHeightResponse{}, e)
+func (ic *IndexerClientTest) TestGetLatest_HeadResponseError() {
+	e := errors.New("new head error")
+	ic.ProxyClient.On("GetHead", mock.AnythingOfType("*context.cancelCtx")).Return(&chainpb.GetHeadResponse{}, e)
 
 	req := structs.LatestDataRequest{
 		LastHeight: uint64(ic.Height[0]),
@@ -400,13 +400,13 @@ func (ic *IndexerClientTest) TestGetLatest_BlockResponseError() {
 		}
 
 		ic.Require().True(response.Final)
-		ic.Require().Contains(response.Error.Msg, "Could not fetch latest block from proxy: new block error")
+		ic.Require().Contains(response.Error.Msg, "Could not fetch head from proxy: new head error")
 		return
 	}
 }
 
 func (ic *IndexerClientTest) TestGetLatest_BlockResponseError2() {
-	ic.ProxyClient.On("GetBlockByHeight", mock.AnythingOfType("*context.cancelCtx"), uint64(0)).Return(utils.BlockResponse(ic.BlockResponse[0]), nil)
+	ic.ProxyClient.On("GetHead", mock.AnythingOfType("*context.cancelCtx")).Return(utils.HeadResponse(int64(ic.Height[0])), nil)
 
 	e := errors.New("new block error")
 	ic.ProxyClient.On("GetBlockByHeight", mock.AnythingOfType("*context.cancelCtx"), ic.Height[0]).Return(&blockpb.GetByHeightResponse{}, e)
@@ -446,7 +446,7 @@ func (ic *IndexerClientTest) TestGetLatest_BlockResponseError2() {
 }
 
 func (ic *IndexerClientTest) TestGetLatest_TransactionResponseError() {
-	ic.ProxyClient.On("GetBlockByHeight", mock.AnythingOfType("*context.cancelCtx"), uint64(0)).Return(utils.BlockResponse(ic.BlockResponse[0]), nil)
+	ic.ProxyClient.On("GetHead", mock.AnythingOfType("*context.cancelCtx")).Return(utils.HeadResponse(int64(ic.Height[0])), nil)
 	ic.ProxyClient.On("GetBlockByHeight", mock.AnythingOfType("*context.cancelCtx"), ic.Height[0]).Return(utils.BlockResponse(ic.BlockResponse[0]), nil)
 
 	e := errors.New("new transaction error")
@@ -487,7 +487,7 @@ func (ic *IndexerClientTest) TestGetLatest_TransactionResponseError() {
 }
 
 func (ic *IndexerClientTest) TestGetLatest_EventResponseError() {
-	ic.ProxyClient.On("GetBlockByHeight", mock.AnythingOfType("*context.cancelCtx"), uint64(0)).Return(utils.BlockResponse(ic.BlockResponse[0]), nil)
+	ic.ProxyClient.On("GetHead", mock.AnythingOfType("*context.cancelCtx")).Return(utils.HeadResponse(int64(ic.Height[0])), nil)
 	ic.ProxyClient.On("GetBlockByHeight", mock.AnythingOfType("*context.cancelCtx"), ic.Height[0]).Return(utils.BlockResponse(ic.BlockResponse[0]), nil)
 	ic.ProxyClient.On("GetTransactionsByHeight", mock.AnythingOfType("*context.cancelCtx"), ic.Height[0]).Return(utils.TransactionsResponse(ic.TransactionsResponse[0]), nil)
 
@@ -529,7 +529,7 @@ func (ic *IndexerClientTest) TestGetLatest_EventResponseError() {
 }
 
 func (ic *IndexerClientTest) TestGetLatest_MetaResponseError() {
-	ic.ProxyClient.On("GetBlockByHeight", mock.AnythingOfType("*context.cancelCtx"), uint64(0)).Return(utils.BlockResponse(ic.BlockResponse[0]), nil)
+	ic.ProxyClient.On("GetHead", mock.AnythingOfType("*context.cancelCtx")).Return(utils.HeadResponse(int64(ic.Height[0])), nil)
 	ic.ProxyClient.On("GetBlockByHeight", mock.AnythingOfType("*context.cancelCtx"), ic.Height[0]).Return(utils.BlockResponse(ic.BlockResponse[0]), nil)
 	ic.ProxyClient.On("GetEventsByHeight", mock.AnythingOfType("*context.cancelCtx"), ic.Height[0]).Return(utils.EventsResponse(ic.EventsResponse[0]), nil)
 	ic.ProxyClient.On("GetTransactionsByHeight", mock.AnythingOfType("*context.cancelCtx"), ic.Height[0]).Return(utils.TransactionsResponse(ic.TransactionsResponse[0]), nil)

--- a/indexer/client_test.go
+++ b/indexer/client_test.go
@@ -901,6 +901,11 @@ func (m proxyClientMock) GetMetaByHeight(ctx context.Context, height uint64) (*c
 	return args.Get(0).(*chainpb.GetMetaByHeightResponse), args.Error(1)
 }
 
+func (m proxyClientMock) GetHead(ctx context.Context) (*chainpb.GetHeadResponse, error) {
+	args := m.Called(ctx)
+	return args.Get(0).(*chainpb.GetHeadResponse), args.Error(1)
+}
+
 func (m proxyClientMock) GetTransactionsByHeight(ctx context.Context, height uint64) (*transactionpb.GetByHeightResponse, error) {
 	args := m.Called(ctx, height)
 	return args.Get(0).(*transactionpb.GetByHeightResponse), args.Error(1)

--- a/proxy/client.go
+++ b/proxy/client.go
@@ -20,6 +20,7 @@ type ClientIface interface {
 	GetAccountBalance(ctx context.Context, account string, height uint64) (*accountpb.GetByHeightResponse, error)
 	GetBlockByHeight(ctx context.Context, height uint64) (*blockpb.GetByHeightResponse, error)
 	GetMetaByHeight(ctx context.Context, height uint64) (*chainpb.GetMetaByHeightResponse, error)
+	GetHead(ctx context.Context) (*chainpb.GetHeadResponse, error)
 	GetEventsByHeight(ctx context.Context, height uint64) (*eventpb.GetByHeightResponse, error)
 	GetTransactionsByHeight(ctx context.Context, height uint64) (*transactionpb.GetByHeightResponse, error)
 }
@@ -108,6 +109,24 @@ func (c *Client) GetMetaByHeight(ctx context.Context, height uint64) (*chainpb.G
 	}
 
 	rawRequestGRPCDuration.WithLabels("GetMetaByHeight", "OK").Observe(time.Since(now).Seconds())
+
+	return res, err
+}
+
+// GetHead returns Chain meta by height
+func (c *Client) GetHead(ctx context.Context) (*chainpb.GetHeadResponse, error) {
+	c.log.Debug("Sending GetHead")
+
+	now := time.Now()
+
+	res, err := c.chainClient.GetHead(ctx, &chainpb.GetHeadRequest{})
+	if err != nil {
+		err = errors.Wrapf(err, "Error while getting head")
+		rawRequestGRPCDuration.WithLabels("GetHead", err.Error()).Observe(time.Since(now).Seconds())
+		return nil, err
+	}
+
+	rawRequestGRPCDuration.WithLabels("GetHead", "OK").Observe(time.Since(now).Seconds())
 
 	return res, err
 }

--- a/proxy/client_test.go
+++ b/proxy/client_test.go
@@ -292,12 +292,17 @@ type transactionClientMock struct {
 	mock.Mock
 }
 
+func (m transactionClientMock) GetAnnotatedByHeight(ctx context.Context, in *transactionpb.GetAnnotatedByHeightRequest, opts ...grpc.CallOption) (*transactionpb.GetAnnotatedByHeightResponse, error) {
+	args := m.Called(ctx, in, opts)
+	return args.Get(0).(*transactionpb.GetAnnotatedByHeightResponse), args.Error(1)
+}
+
 func (m transactionClientMock) GetByHeight(ctx context.Context, in *transactionpb.GetByHeightRequest, opts ...grpc.CallOption) (*transactionpb.GetByHeightResponse, error) {
 	args := m.Called(ctx, in, opts)
 	return args.Get(0).(*transactionpb.GetByHeightResponse), args.Error(1)
 }
 
-func (m transactionClientMock) GetAnnotatedByHeight(ctx context.Context, in *transactionpb.GetAnnotatedByHeightRequest, opts ...grpc.CallOption) (*transactionpb.GetAnnotatedByHeightResponse, error) {
-	args := m.Called(ctx, in, opts)
-	return args.Get(0).(*transactionpb.GetAnnotatedByHeightResponse), args.Error(1)
+func (m transactionClientMock) GetHead(ctx context.Context) (*chainpb.GetHeadResponse, error) {
+	args := m.Called(ctx)
+	return args.Get(0).(*chainpb.GetHeadResponse), args.Error(1)
 }

--- a/utils/test_utils.go
+++ b/utils/test_utils.go
@@ -34,6 +34,12 @@ func BlockResponse(resp BlockResp) *blockpb.GetByHeightResponse {
 	}
 }
 
+func HeadResponse(height int64) *chainpb.GetHeadResponse {
+	return &chainpb.GetHeadResponse{
+		Height: height,
+	}
+}
+
 type EventsResp struct {
 	Index          int64
 	ExtrinsicIndex int64


### PR DESCRIPTION
Looks like fetching block at height 0 doesn't fetch latest block, and whatever its fetching is erroring when calculating fee:

```
Mar 24 14:10:08 dh--indexer--polkadot-search--mainnet--1 manager[28056]: {"level":"error","time":"2021-03-24T14:10:08.859Z","msg":"[Scheduler - Process] Error running  bf22f3de-61b2-48b9-b285-e0341ddd32e8 Polkadot Polkadot 0.0.1","error":"error in runner: error getting data from GetLastData [lastdata]:  error in runner: error getting response from ScrapeLatest:  error getting response: Could not fetch latest block from proxy: Error while getting block by height: 0: rpc error: code = Unavailable desc = could not calculate fee , unrecoverable: false , unrecoverable: false"}
```