### PR TITLE
Ctx timeouts

### DIFF
--- a/cmd/polkadot-worker/config/config.go
+++ b/cmd/polkadot-worker/config/config.go
@@ -37,6 +37,7 @@ type Config struct {
 	Hostname        string        `json:"hostname" envconfig:"HOSTNAME"`
 
 	MaximumHeightsToGet float64 `json:"maximum_heights_to_get" envconfig:"MAXIMUM_HEIGHTS_TO_GET" default:"10000"`
+	ReqPerSecond        int     `json:"requests_per_second" envconfig:"REQUESTS_PER_SECOND" default:"20"`
 
 	// Rollbar
 	RollbarAccessToken string `json:"rollbar_access_token" envconfig:"ROLLBAR_ACCESS_TOKEN"`

--- a/cmd/polkadot-worker/main.go
+++ b/cmd/polkadot-worker/main.go
@@ -14,6 +14,7 @@ import (
 	"github.com/figment-networks/polkadot-worker/cmd/polkadot-worker/logger"
 	"github.com/figment-networks/polkadot-worker/indexer"
 	"github.com/figment-networks/polkadot-worker/proxy"
+	"golang.org/x/time/rate"
 
 	"github.com/figment-networks/indexer-manager/worker/connectivity"
 	grpcIndexer "github.com/figment-networks/indexer-manager/worker/transport/grpc"
@@ -132,8 +133,11 @@ func getConfig(path string) (cfg *config.Config, err error) {
 }
 
 func createIndexerClient(ctx context.Context, log *zap.Logger, cfg *config.Config, conn *grpc.ClientConn) *indexer.Client {
+	rateLimiter := rate.NewLimiter(rate.Limit(cfg.ReqPerSecond), cfg.ReqPerSecond)
+
 	proxyClient := proxy.NewClient(
 		log,
+		rateLimiter,
 		accountpb.NewAccountServiceClient(conn),
 		blockpb.NewBlockServiceClient(conn),
 		chainpb.NewChainServiceClient(conn),

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/rollbar/rollbar-go v1.2.0
 	github.com/stretchr/testify v1.7.0
 	go.uber.org/zap v1.16.0
+	golang.org/x/time v0.0.0-20200630173020-3af7569d3a1e
 	google.golang.org/grpc v1.36.0
 	google.golang.org/protobuf v1.26.0
 )

--- a/go.sum
+++ b/go.sum
@@ -503,6 +503,7 @@ golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/time v0.0.0-20181108054448-85acf8d2951c/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20190308202827-9d24e82272b4/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20191024005414-555d28b269f0/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
+golang.org/x/time v0.0.0-20200630173020-3af7569d3a1e h1:EHBhcS0mlXEAVwNyO2dLfjToGsyY4j24pTs2ScHnX7s=
 golang.org/x/time v0.0.0-20200630173020-3af7569d3a1e/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20181030221726-6c7e314b6563/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=

--- a/indexer/client.go
+++ b/indexer/client.go
@@ -245,7 +245,7 @@ func (c *Client) GetLatest(ctx context.Context, tr cStructs.TaskRequest, stream 
 
 	hr := c.getLatestBlockHeightRange(ctx, ldr.LastHeight, uint64(block.Block.Header.Height))
 
-	if err := c.sendTransactionsInRange(ctx, hr, out); err != nil {
+	if err := sendTransactionsInRange(ctx, c.log, c, hr, out); err != nil {
 		stream.Send(cStructs.TaskResponse{
 			Id:    tr.Id,
 			Error: cStructs.TaskError{Msg: fmt.Sprintf("Error while getting Transactions with given range: %s", err.Error())},
@@ -338,7 +338,7 @@ func (c *Client) GetTransactions(ctx context.Context, tr cStructs.TaskRequest, s
 
 	go c.sendRespLoop(ctx, tr.Id, out, stream, fin)
 
-	if err := c.sendTransactionsInRange(ctx, hr, out); err != nil {
+	if err := sendTransactionsInRange(ctx, c.log, c, hr, out); err != nil {
 		stream.Send(cStructs.TaskResponse{
 			Id: tr.Id,
 			Error: cStructs.TaskError{
@@ -422,36 +422,179 @@ func (c *Client) sendResp(id uuid.UUID, taskType string, payload interface{}, or
 	}
 }
 
-func (c *Client) sendTransactionsInRange(ctx context.Context, hr structs.HeightRange, out chan cStructs.OutResp) error {
-	var wg sync.WaitGroup
-	actualHeight := hr.StartHeight
+type hBTx struct {
+	Height uint64
+	Last   bool
+	Ch     chan cStructs.OutResp
+}
 
-	defer c.log.Sync()
+// getRange gets given range of blocks and transactions
+func sendTransactionsInRange(ctx context.Context, logger *zap.Logger, client *Client, hr structs.HeightRange, out chan cStructs.OutResp) (err error) {
+	defer logger.Sync()
 
-	count := int(hr.EndHeight - hr.StartHeight + 1)
-	wg.Add(count)
-	errChan := make(chan error, count)
+	chIn := oHBTxPool.Get()
+	chOut := oHBTxPool.Get()
+
+	errored := make(chan bool, 7)
+	defer close(errored)
+
+	wg := &sync.WaitGroup{}
+	for i := 0; i < 5; i++ {
+		wg.Add(1)
+		go asyncBlockAndTx(ctx, logger, wg, client, chIn)
+	}
+	go populateRange(chIn, chOut, hr, errored)
+
+RANGE_LOOP:
+	for {
+		select {
+		// (lukanus): add timeout
+		case o := <-chOut:
+			if o.Last {
+				logger.Debug("[COSMOS-CLIENT] Finished sending height", zap.Uint64("height", o.Height))
+				break RANGE_LOOP
+			}
+
+		INNER_LOOP:
+			for resp := range o.Ch {
+				switch resp.Type {
+				case "Partial":
+					break INNER_LOOP
+				case "Error":
+					errored <- true // (lukanus): to close publisher and asyncBlockAndTx
+					err = resp.Error
+					out <- resp
+					break RANGE_LOOP
+				default:
+					out <- resp
+				}
+			}
+			oRespPool.Put(o.Ch)
+		}
+	}
+
+	if err != nil { // (lukanus): discard everything on error, after error
+		wg.Wait() // (lukanus): make sure there are no outstanding producers
+	PURIFY_CHANNELS:
+		for {
+			select {
+			case o := <-chOut:
+				if o.Ch != nil {
+				PURIFY_INNER_CHANNELS:
+					for {
+						select {
+						case <-o.Ch:
+						default:
+							break PURIFY_INNER_CHANNELS
+						}
+					}
+				}
+				oRespPool.Put(o.Ch)
+			default:
+				break PURIFY_CHANNELS
+			}
+		}
+	}
+	oHBTxPool.Put(chOut)
+	return err
+}
+
+func populateRange(in, out chan hBTx, hr structs.HeightRange, er chan bool) {
+	height := hr.StartHeight
 
 	for {
-		c.log.Debug("Sending transactions", zap.Uint64("height", actualHeight))
-
-		c.sendTransactionsByHeight(ctx, out, actualHeight, &wg, errChan)
-
-		if actualHeight == hr.EndHeight {
+		hBTxO := hBTx{Height: height, Ch: oRespPool.Get()}
+		select {
+		case out <- hBTxO:
+		case <-er:
 			break
 		}
 
-		actualHeight++
+		select {
+		case in <- hBTxO:
+		case <-er:
+			break
+		}
+
+		height++
+		if height > hr.EndHeight {
+			select {
+			case out <- hBTx{Last: true}:
+			case <-er:
+			}
+			break
+		}
+
+	}
+	close(in)
+}
+
+func asyncBlockAndTx(ctx context.Context, logger *zap.Logger, wg *sync.WaitGroup, client *Client, cinn chan hBTx) {
+	defer wg.Done()
+	for in := range cinn {
+		b, txs, err := blockAndTx(ctx, logger, client, in.Height)
+		if err != nil {
+			in.Ch <- cStructs.OutResp{
+				Error: err,
+				Type:  "Error",
+			}
+			return
+		}
+		in.Ch <- cStructs.OutResp{
+			Type:    "Block",
+			Payload: b,
+		}
+		if txs != nil {
+			for _, t := range txs {
+				in.Ch <- cStructs.OutResp{
+					Type:    "Transaction",
+					Payload: t,
+				}
+			}
+		}
+
+		in.Ch <- cStructs.OutResp{
+			Type: "Partial",
+		}
+	}
+}
+
+func blockAndTx(ctx context.Context, logger *zap.Logger, c *Client, height uint64) (block *structs.Block, transactions []*structs.Transaction, err error) {
+	blResp, err := c.proxy.GetBlockByHeight(ctx, height)
+	if err != nil {
+		return nil, nil, err
 	}
 
-	wg.Wait()
-	close(errChan)
-
-	if err := c.wrapErrorsFromChan(errChan); err != nil {
-		return err
+	trResp, err := c.proxy.GetTransactionsByHeight(ctx, height)
+	if err != nil {
+		return nil, nil, err
 	}
 
-	return nil
+	if trResp == nil {
+		return mapper.BlockMapper(blResp, c.chainID, 0), nil, nil
+	}
+
+	block = mapper.BlockMapper(
+		blResp,
+		c.chainID,
+		uint64(len(trResp.Transactions)),
+	)
+
+	evResp, err := c.proxy.GetEventsByHeight(ctx, height)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	metaResp, err := c.proxy.GetMetaByHeight(ctx, height)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	if transactions, err = c.trMapper.TransactionsMapper(c.log, blResp, evResp, metaResp, trResp); err != nil {
+		return nil, nil, err
+	}
+
+	return
 }
 
 func (c *Client) sendTransactionsByHeight(ctx context.Context, out chan cStructs.OutResp, height uint64, wg *sync.WaitGroup, err chan error) {

--- a/indexer/client.go
+++ b/indexer/client.go
@@ -103,7 +103,7 @@ func (c *Client) Run(ctx context.Context, stream *cStructs.StreamAccess) {
 		case taskRequest := <-stream.RequestListener:
 			c.log.Debug("Received task request", zap.Stringer("taskID", taskRequest.Id), zap.String("type", taskRequest.Type))
 
-			ctxWithTimeout, cancel := context.WithTimeout(ctx, 5*time.Minute)
+			ctxWithTimeout, cancel := context.WithTimeout(ctx, 10*time.Minute)
 			defer cancel()
 
 			switch taskRequest.Type {

--- a/indexer/client_test.go
+++ b/indexer/client_test.go
@@ -566,7 +566,7 @@ func (ic *IndexerClientTest) TestGetLatest_MetaResponseError() {
 		}
 
 		ic.Require().True(response.Final)
-		ic.Require().Contains(response.Error.Msg, "Error while getting Transactions with given range: new meta error ")
+		ic.Require().Contains(response.Error.Msg, "Error while getting Transactions with given range: new meta error")
 		return
 	}
 }
@@ -819,7 +819,7 @@ func (ic *IndexerClientTest) TestGetTransactions_GetEventByHeightError() {
 			continue
 		}
 
-		ic.Require().Contains(response.Error.Msg, "Error while sending Transactions with given range: new event error one , new event error two")
+		ic.Require().Contains(response.Error.Msg, "Error while sending Transactions with given range: new event error one")
 		return
 	}
 }

--- a/indexer/pool.go
+++ b/indexer/pool.go
@@ -1,0 +1,108 @@
+package indexer
+
+import (
+	"sync"
+
+	cStructs "github.com/figment-networks/indexer-manager/worker/connectivity/structs"
+)
+
+var (
+	oRespPool = NewOutRespPool(20)
+	oHBTxPool = NewHBTxPool(20)
+)
+
+type outRespPool struct {
+	stor chan chan cStructs.OutResp
+	lock *sync.Mutex
+}
+
+func NewOutRespPool(cap int) *outRespPool {
+	return &outRespPool{
+		stor: make(chan chan cStructs.OutResp, cap),
+		lock: &sync.Mutex{},
+	}
+}
+
+func (o *outRespPool) Get() chan cStructs.OutResp {
+	o.lock.Lock()
+	defer o.lock.Unlock()
+	select {
+	case a := <-o.stor:
+		// (lukanus): better safe than sorry
+		outRespDrain(a)
+		return a
+	default:
+	}
+
+	return make(chan cStructs.OutResp, 1000)
+}
+
+func (o *outRespPool) Put(or chan cStructs.OutResp) {
+	o.lock.Lock()
+	defer o.lock.Unlock()
+	select {
+	case o.stor <- or:
+	default:
+		close(or)
+	}
+
+	return
+}
+
+type hBTxPool struct {
+	stor chan chan hBTx
+	lock *sync.Mutex
+}
+
+func NewHBTxPool(cap int) *hBTxPool {
+	return &hBTxPool{
+		stor: make(chan chan hBTx, cap),
+		lock: &sync.Mutex{},
+	}
+}
+
+func (o *hBTxPool) Get() chan hBTx {
+	o.lock.Lock()
+	defer o.lock.Unlock()
+	select {
+	case a := <-o.stor:
+		// (lukanus): better safe than sorry
+		hBTxDrain(a)
+		return a
+	default:
+	}
+
+	return make(chan hBTx, 10)
+}
+
+func (o *hBTxPool) Put(or chan hBTx) {
+	o.lock.Lock()
+	defer o.lock.Unlock()
+	select {
+	case o.stor <- or:
+	default:
+		close(or)
+	}
+
+	return
+}
+
+func hBTxDrain(c chan hBTx) {
+	for {
+		select {
+		case <-c:
+		default:
+			return
+		}
+	}
+}
+
+func outRespDrain(c chan cStructs.OutResp) {
+	for {
+		select {
+		case <-c:
+		default:
+			return
+		}
+	}
+}

--- a/mapper/block_mapper.go
+++ b/mapper/block_mapper.go
@@ -9,17 +9,17 @@ import (
 )
 
 // BlockMapper maps polkadothub-proxy Block to indexer-manager Block
-func BlockMapper(block *blockpb.GetByHeightResponse, chainID string, numberOfTransactions uint64) structs.Block {
+func BlockMapper(block *blockpb.GetByHeightResponse, chainID string, numberOfTransactions uint64) *structs.Block {
 	timer := metrics.NewTimer(conversionDuration.WithLabels("block"))
 	defer timer.ObserveDuration()
 
 	if block == nil {
-		return structs.Block{}
+		return nil
 	}
 
 	time := block.Block.Header.Time.AsTime()
 
-	return structs.Block{
+	return &structs.Block{
 		ChainID:              chainID,
 		Epoch:                strconv.Itoa(int(time.Unix())),
 		Hash:                 block.Block.BlockHash,

--- a/proxy/client.go
+++ b/proxy/client.go
@@ -9,6 +9,7 @@ import (
 	"github.com/figment-networks/polkadothub-proxy/grpc/chain/chainpb"
 	"github.com/figment-networks/polkadothub-proxy/grpc/event/eventpb"
 	"github.com/figment-networks/polkadothub-proxy/grpc/transaction/transactionpb"
+	"golang.org/x/time/rate"
 	"google.golang.org/grpc"
 
 	"github.com/pkg/errors"
@@ -28,6 +29,8 @@ type ClientIface interface {
 type Client struct {
 	log *zap.Logger
 
+	rateLimiter *rate.Limiter
+
 	accountClient     accountpb.AccountServiceClient
 	blockClient       blockpb.BlockServiceClient
 	chainClient       chainpb.ChainServiceClient
@@ -36,14 +39,19 @@ type Client struct {
 }
 
 // NewClient is a polkadot-proxy Client constructor
-func NewClient(log *zap.Logger, ac accountpb.AccountServiceClient, bc blockpb.BlockServiceClient,
+func NewClient(log *zap.Logger, rl *rate.Limiter, ac accountpb.AccountServiceClient, bc blockpb.BlockServiceClient,
 	cc chainpb.ChainServiceClient, ec eventpb.EventServiceClient, tc transactionpb.TransactionServiceClient) *Client {
-	return &Client{log: log, accountClient: ac, blockClient: bc, chainClient: cc, eventClient: ec, transactionClient: tc}
+	return &Client{log: log, rateLimiter: rl, accountClient: ac, blockClient: bc, chainClient: cc, eventClient: ec, transactionClient: tc}
 }
 
 // GetAccountBalance return Account Balance by provided height
 func (c *Client) GetAccountBalance(ctx context.Context, account string, height uint64) (*accountpb.GetByHeightResponse, error) {
 	c.log.Debug("Sending GetAccountBalanceByHeight height", zap.Uint64("height", height))
+
+	err := c.rateLimiter.Wait(ctx)
+	if err != nil {
+		return nil, err
+	}
 
 	now := time.Now()
 
@@ -63,6 +71,11 @@ func (c *Client) GetAccountBalance(ctx context.Context, account string, height u
 func (c *Client) GetBlockByHeight(ctx context.Context, height uint64) (*blockpb.GetByHeightResponse, error) {
 	c.log.Debug("Sending GetBlockByHeight height", zap.Uint64("height", height))
 
+	err := c.rateLimiter.Wait(ctx)
+	if err != nil {
+		return nil, err
+	}
+
 	now := time.Now()
 	res, err := c.blockClient.GetByHeight(ctx, &blockpb.GetByHeightRequest{Height: int64(height)}, grpc.WaitForReady(true))
 	if err != nil {
@@ -79,6 +92,11 @@ func (c *Client) GetBlockByHeight(ctx context.Context, height uint64) (*blockpb.
 // GetEventsByHeight returns Event by height
 func (c *Client) GetEventsByHeight(ctx context.Context, height uint64) (*eventpb.GetByHeightResponse, error) {
 	c.log.Debug("Sending GetEventsByHeight height", zap.Uint64("height", height))
+
+	err := c.rateLimiter.Wait(ctx)
+	if err != nil {
+		return nil, err
+	}
 
 	now := time.Now()
 
@@ -98,6 +116,11 @@ func (c *Client) GetEventsByHeight(ctx context.Context, height uint64) (*eventpb
 func (c *Client) GetMetaByHeight(ctx context.Context, height uint64) (*chainpb.GetMetaByHeightResponse, error) {
 	c.log.Debug("Sending GetMetaByHeight height", zap.Uint64("height", height))
 
+	err := c.rateLimiter.Wait(ctx)
+	if err != nil {
+		return nil, err
+	}
+
 	now := time.Now()
 
 	res, err := c.chainClient.GetMetaByHeight(ctx, &chainpb.GetMetaByHeightRequest{Height: int64(height)})
@@ -116,6 +139,11 @@ func (c *Client) GetMetaByHeight(ctx context.Context, height uint64) (*chainpb.G
 func (c *Client) GetTransactionsByHeight(ctx context.Context, height uint64) (*transactionpb.GetByHeightResponse, error) {
 	req := &transactionpb.GetByHeightRequest{
 		Height: int64(height),
+	}
+
+	err := c.rateLimiter.Wait(ctx)
+	if err != nil {
+		return nil, err
 	}
 
 	c.log.Debug("Sending GetTransactionsByHeight height", zap.Uint64("height", height))


### PR DESCRIPTION
Increased context timeout because syncing large height ranges are having issues.
Also added rate-limiter so we don't stress out the node.


Seems like fetching from earlier heights on the chain is just a looot slower. So looks like we can at least sync more recent heights with large batch calls, but getting the earlier heights will take some effort/patience (or automation...)

1000 heights took ~1.5sec
```
{"level":"debug","time":"2021-03-24T18:57:43.684-0400","msg":"Sending GetBlockByHeight height","height":4329490}
...
{"level":"debug","time":"2021-03-24T18:59:00.960-0400","msg":"Sending GetMetaByHeight height","height":4330489}
{"level":"debug","time":"2021-03-24T18:59:01.175-0400","msg":"[COSMOS-CLIENT] Finished sending height","height":0}
```

175 heights took~5min
```
{"level":"debug","time":"2021-03-24T18:59:45.178-0400","msg":"Sending GetBlockByHeight height","height":5000}
....
{"level":"debug","time":"2021-03-24T19:04:22.160-0400","msg":"Sending GetTransactionsByHeight height","height":5175}

```
